### PR TITLE
Initial implementation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,7 @@ jobs:
       matrix:
         scenario:
           - default
+          - no_settings
     steps:
       - id: harden-runner
         name: Harden the runner

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,7 +126,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/(default|systemd_enabled)/tests
+        exclude: molecule/(default|no_settings)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ None.
 > Although none of the variables that control settings are individually required,
 > at least one of them must be defined.
 
+<!--
+Note:
+The order of any setting's valid values is intentionally _not_ enforced in alphabetical
+order. They instead match the output of a `cat /path/to/setting` command on a live
+system so that it is easier to cross-reference the setting values with what one would
+see when configuring Transparent HugePage settings manually.
+-->
+
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | manage\_thp\_defrag\_path | The sysfs path to control the Transparent HugePage `defrag` setting. | `/sys/kernel/mm/transparent_hugepage/defrag` | No |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ None.
 | manage\_thp\_enabled\_path | The sysfs path to control the Transparent HugePage `enabled` setting. | `/sys/kernel/mm/transparent_hugepage/enabled` | No |
 | manage\_thp\_enabled\_setting | A value of `always`, `madvise`, or `never`. Please see the [kernel documentation] for more information. | n/a | No |
 | manage\_thp\_service\_name | The name of the SystemD service that is created to manage Transparent HugePage settings. Please note that `.service` is appended to this value in the name of the unit file created. | `configure-transparent-hugepage-settings` | No |
+| manage\_thp\_shmem\_enabled\_path | The sysfs path to control the Transparent HugePage `shmem_enabled` setting. | `/sys/kernel/mm/transparent_hugepage/shmem_enabled` | No |
+| manage\_thp\_shmem\_enabled\_setting | If defined it must be a value of `always`, `within_size`, `advise`, `never`, `deny`, or `force`. Please see the [kernel documentation] for more information. | n/a | No |
 | manage\_thp\_start\_before\_service | The name of the service that the SystemD unit file should be configured to start before. Please note that `.service` is appended to this value in the definition of the `Before` directive. | n/a | No |
+| manage\_thp\_use\_zero\_page\_path | The sysfs path to control the Transparent HugePage `use_zero_page` setting. | `/sys/kernel/mm/transparent_hugepage/use_zero_page` | No |
+| manage\_thp\_use\_zero\_page\_setting | If defined it must be a value of `0` or `1`. Please see the [kernel documentation] for more information. | n/a | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ None.
 
 ## Role Variables ##
 
+> [!NOTE]
+> Although none of the variables that control settings are individually required,
+> at least one of them must be defined.
+
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | manage\_thp\_defrag\_path | The sysfs path to control the Transparent HugePage `defrag` setting. | `/sys/kernel/mm/transparent_hugepage/defrag` | No |

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ None.
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | manage\_thp\_defrag\_path | The sysfs path to control the Transparent HugePage `defrag` setting. | `/sys/kernel/mm/transparent_hugepage/defrag` | No |
-| manage\_thp\_defrag\_setting | If defined it must be a value of `always`, `defer`, `defer+madvise`, `madvise`, or `never`. Please see the [kernel documentation] for more information. | n/a | No |
+| manage\_thp\_defrag\_setting | If defined this variable must be given a value of `always`, `defer`, `defer+madvise`, `madvise`, or `never`. Please see the [kernel documentation] for more information. | n/a | No |
 | manage\_thp\_enabled\_path | The sysfs path to control the Transparent HugePage `enabled` setting. | `/sys/kernel/mm/transparent_hugepage/enabled` | No |
-| manage\_thp\_enabled\_setting | A value of `always`, `madvise`, or `never`. Please see the [kernel documentation] for more information. | n/a | No |
+| manage\_thp\_enabled\_setting | If defined this variable must be given a value of `always`, `madvise`, or `never`. Please see the [kernel documentation] for more information. | n/a | No |
 | manage\_thp\_service\_name | The name of the SystemD service that is created to manage Transparent HugePage settings. Please note that `.service` is appended to this value in the name of the unit file created. | `configure-transparent-hugepage-settings` | No |
 | manage\_thp\_shmem\_enabled\_path | The sysfs path to control the Transparent HugePage `shmem_enabled` setting. | `/sys/kernel/mm/transparent_hugepage/shmem_enabled` | No |
-| manage\_thp\_shmem\_enabled\_setting | If defined it must be a value of `always`, `within_size`, `advise`, `never`, `deny`, or `force`. Please see the [kernel documentation] for more information. | n/a | No |
+| manage\_thp\_shmem\_enabled\_setting | If defined this variable must be given a value of `always`, `within_size`, `advise`, `never`, `deny`, or `force`. Please see the [kernel documentation] for more information. | n/a | No |
 | manage\_thp\_start\_before\_service | The name of the service that the SystemD unit file should be configured to start before. Please note that `.service` is appended to this value in the definition of the `Before` directive. | n/a | No |
 | manage\_thp\_use\_zero\_page\_path | The sysfs path to control the Transparent HugePage `use_zero_page` setting. | `/sys/kernel/mm/transparent_hugepage/use_zero_page` | No |
-| manage\_thp\_use\_zero\_page\_setting | If defined it must be a value of `0` or `1`. Please see the [kernel documentation] for more information. | n/a | No |
+| manage\_thp\_use\_zero\_page\_setting | If defined this variable must be given a value of `0` or `1`. Please see the [kernel documentation] for more information. | n/a | No |
 
 ## Dependencies ##
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,10 @@
 [![GitHub Build Status](https://github.com/cisagov/ansible-role-manage-thp/workflows/build/badge.svg)](https://github.com/cisagov/ansible-role-manage-thp/actions)
 [![CodeQL](https://github.com/cisagov/ansible-role-manage-thp/workflows/CodeQL/badge.svg)](https://github.com/cisagov/ansible-role-manage-thp/actions/workflows/codeql-analysis.yml)
 
-This is a skeleton project that can be used to quickly get a new
-[cisagov](https://github.com/cisagov) Ansible role GitHub project
-started.  This skeleton project contains
-[licensing information](LICENSE), as well as
-[pre-commit hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for an Ansible role.
+An Ansible role that creates a SystemD unit to manage Transparent HugePage (THP)
+settings on Linux systems. This role is inspired by the
+[GekoCloud/ansible-role-disable-thp](https://github.com/GekoCloud/ansible-role-disable-thp)
+role.
 
 ## Requirements ##
 
@@ -17,14 +14,14 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
-| required_variable | Describe its purpose. | n/a | Yes |
--->
+| manage\_thp\_defrag\_path | The sysfs path to control the Transparent HugePage `defrag` setting. | `/sys/kernel/mm/transparent_hugepage/defrag` | No |
+| manage\_thp\_defrag\_setting | If defined it must be a value of `always`, `defer`, `defer+madvise`, `madvise`, or `never`. Please see the [kernel documentation] for more information. | n/a | No |
+| manage\_thp\_enabled\_path | The sysfs path to control the Transparent HugePage `enabled` setting. | `/sys/kernel/mm/transparent_hugepage/enabled` | No |
+| manage\_thp\_enabled\_setting | A value of `always`, `madvise`, or `never`. Please see the [kernel documentation] for more information. | n/a | No |
+| manage\_thp\_service\_name | The name of the SystemD service that is created to manage Transparent HugePage settings. Please note that `.service` is appended to this value in the name of the unit file created. | `configure-transparent-hugepage-settings` | No |
+| manage\_thp\_start\_before\_service | The name of the service that the SystemD unit file should be configured to start before. Please note that `.service` is appended to this value in the definition of the `Before` directive. | n/a | No |
 
 ## Dependencies ##
 
@@ -61,17 +58,12 @@ Here's how to use it in a playbook:
   become: true
   become_method: sudo
   tasks:
-    - name: Include skeleton
+    - name: Manage Transparent HugePage settings
       ansible.builtin.include_role:
-        name: skeleton
+        name: manage_thp
+      vars:
+        manage_thp_enabled_setting: never
 ```
-
-## New Repositories from a Skeleton ##
-
-Please see our [Project Setup guide](https://github.com/cisagov/development-guide/tree/develop/project_setup)
-for step-by-step instructions on how to start a new repository from
-a skeleton. This will save you time and effort when configuring a
-new repository!
 
 ## Contributing ##
 
@@ -93,4 +85,6 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-First Last - <first.last@gwe.cisa.dhs.gov>
+Nicholas McDonnell - <nicholas.mcdonnell@gwe.cisa.dhs.gov>
+
+[kernel documentation]: https://www.kernel.org/doc/html/next/admin-guide/mm/transhuge.html#global-thp-controls

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# Path to manage the Transparent HugePage `defrag` setting
+manage_thp_defrag_path: /sys/kernel/mm/transparent_hugepage/defrag
+# Value must be one of: always, defer, defer+madvise, madvise, or never
+manage_thp_defrag_setting: never
+
+# Path to manage the Transparent HugePage `enabled` setting
+manage_thp_enabled_path: /sys/kernel/mm/transparent_hugepage/enabled
+# Value must be one of: always, madvise, or never
+manage_thp_enabled_setting: never
+
+# Name of the service to configure the Transparent HugePage settings
+manage_thp_service_name: configure-transparent-hugepage-settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,5 +5,11 @@ manage_thp_defrag_path: /sys/kernel/mm/transparent_hugepage/defrag
 # Path to manage the Transparent HugePage `enabled` setting
 manage_thp_enabled_path: /sys/kernel/mm/transparent_hugepage/enabled
 
+# Path to manage the Transparent HugePage `shmem_enabled` setting
+manage_thp_shmem_enabled_path: /sys/kernel/mm/transparent_hugepage/shmem_enabled
+
+# Path to manage the Transparent HugePage `use_zero_page` setting
+manage_thp_use_zero_page_path: /sys/kernel/mm/transparent_hugepage/use_zero_page
+
 # Name of the service to configure the Transparent HugePage settings
 manage_thp_service_name: configure-transparent-hugepage-settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,13 +1,9 @@
 ---
 # Path to manage the Transparent HugePage `defrag` setting
 manage_thp_defrag_path: /sys/kernel/mm/transparent_hugepage/defrag
-# Value must be one of: always, defer, defer+madvise, madvise, or never
-manage_thp_defrag_setting: never
 
 # Path to manage the Transparent HugePage `enabled` setting
 manage_thp_enabled_path: /sys/kernel/mm/transparent_hugepage/enabled
-# Value must be one of: always, madvise, or never
-manage_thp_enabled_setting: never
 
 # Name of the service to configure the Transparent HugePage settings
 manage_thp_service_name: configure-transparent-hugepage-settings

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: SystemD daemon-reload
+  ansible.builtin.systemd:
+    daemon_reload: true
+  listen: systemd daemon-reload

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,11 +6,12 @@
 # See also cisagov/ansible-role-manage-thp#153.
 dependencies: []
 galaxy_info:
-  author: First Last
+  author: Nicholas McDonnell
   company: CISA Cyber Assessments
-  description: Skeleton Ansible role
+  description: Ansible role to configure a SystemD service to manage Transparent HugePage (THP) settings.
   galaxy_tags:
-    - skeleton
+    - hugepage
+    - thp
   license: CC0
   # With the release of version 2.10, Ansible finally correctly
   # identifies Kali Linux as being the Kali distribution of the Debian
@@ -40,5 +41,5 @@ galaxy_info:
       versions:
         - focal
         - jammy
-  role_name: skeleton
+  role_name: manage_thp
   standalone: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,3 +5,5 @@
     - name: Include ansible-role-manage-thp
       ansible.builtin.include_role:
         name: ansible-role-manage-thp
+      vars:
+        manage_thp_enabled_setting: never

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -20,4 +20,5 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 )
 def test_configure_thp_service(host, service):
     """Test that any services created are enabled."""
-    assert host.service(service).is_enabled, f"The {service} service is not enabled"
+    svc = host.service(service)
+    assert svc.is_enabled, f"The {service} service is not enabled"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("x", [True])
-def test_packages(host, x):
-    """Run a dummy test, just to show what one would look like."""
-    assert x
+@pytest.mark.parametrize(
+    "service",
+    [
+        "configure-transparent-hugepage-settings",
+    ],
+)
+def test_configure_thp_service(host, service):
+    """Test that any services created are enabled."""
+    assert host.service(service).is_enabled, f"The {service} service is not enabled"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -22,3 +22,6 @@ def test_configure_thp_service(host, service):
     """Test that any services created are enabled."""
     svc = host.service(service)
     assert svc.is_enabled, f"The {service} service is not enabled"
+    # This command takes a unit file path to verify
+    res = host.run(f'systemd-analyze verify {svc.systemd_properties["FragmentPath"]}')
+    assert res.succeeded, f"The {service} service is not valid"

--- a/molecule/no_settings/INSTALL.rst
+++ b/molecule/no_settings/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/no_settings/converge.yml
+++ b/molecule/no_settings/converge.yml
@@ -1,0 +1,19 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Test the role in a scenario where it is expected to fail
+      block:
+        - name: Include ansible-role-manage-thp
+          ansible.builtin.include_role:
+            name: ansible-role-manage-thp
+      rescue:
+        - name: Verify expected failure
+          ansible.builtin.assert:
+            fail_msg: Expected failure did not occur
+            that:
+              - ansible_failed_task is defined
+              - ansible_failed_task.name == "Verify that at least one Transparent HugePage setting is provided"
+              - ansible_failed_result is defined
+              - ansible_failed_result.changed is false
+              - ansible_failed_result.failed is true

--- a/molecule/no_settings/molecule.yml
+++ b/molecule/no_settings/molecule.yml
@@ -1,0 +1,100 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian10-ansible:latest
+    name: debian10-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian11-ansible:latest
+    name: debian11-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest
+    name: debian12-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+    name: ubuntu-20-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
+    name: ubuntu-22-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+scenario:
+  name: no_settings
+verifier:
+  name: testinfra

--- a/molecule/no_settings/prepare.yml
+++ b/molecule/no_settings/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/no_settings/requirements.yml
+++ b/molecule/no_settings/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/no_settings/tests/test_no_settings.py
+++ b/molecule/no_settings/tests/test_no_settings.py
@@ -1,0 +1,31 @@
+"""Module containing the tests for the no_settings scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import pytest
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        "configure-transparent-hugepage-settings",
+    ],
+)
+def test_no_configure_thp_service(host, service):
+    """Test that no services were created."""
+    svc = host.service(service)
+    # TODO: We cannot use this test because of pytest-dev/pytest-testinfra#757,
+    # which would be resolved with the merge of pytest-dev/pytest-testinfra#754.
+    # Once that pull request has been merged and a new release is cut we can use
+    # the following test instead of the workaround being used below. Please see
+    # #5 for details and tracking.
+    # assert svc.exists is False, f"The {service} service exists"
+    load_state = svc.systemd_properties["LoadState"]
+    assert load_state == "not-found", f"The {service} service exists"

--- a/molecule/no_settings/upgrade.yml
+++ b/molecule/no_settings/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,24 @@
 ---
-# tasks file for skeleton
+- name: Verify the provided Transparent HugePage "defrag" setting
+  ansible.builtin.assert:
+    fail_msg: The provided Transparent HugePage "defrag" setting is not valid
+    that:
+      - manage_thp_defrag_setting in ['always', 'defer', 'defer+madvise', 'madvise', 'never']
+
+- name: Verify the provided Transparent HugePage "enabled" setting
+  ansible.builtin.assert:
+    fail_msg: The provided Transparent HugePage "enabled" setting is not valid
+    that:
+      - manage_thp_enabled_setting in ['always', 'madvise', 'never']
+
+- name: Create the unit file to configure Transparent HugePage settings
+  ansible.builtin.template:
+    dest: /etc/systemd/system/{{ manage_thp_service_name }}.service
+    mode: 0644
+    src: configure-thp.service.j2
+  notify: systemd daemon-reload
+
+- name: Enable the service to configure Transparent HugePage settings
+  ansible.builtin.service:
+    enabled: true
+    name: "{{ manage_thp_service_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
     fail_msg: The provided Transparent HugePage "defrag" setting is not valid
     that:
       - manage_thp_defrag_setting in ['always', 'defer', 'defer+madvise', 'madvise', 'never']
+  when:
+    - manage_thp_defrag_setting is defined
 
 - name: Verify the provided Transparent HugePage "enabled" setting
   ansible.builtin.assert:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,22 @@
     that:
       - manage_thp_enabled_setting in ['always', 'madvise', 'never']
 
+- name: Verify the provided Transparent HugePage shmem_enabled setting
+  ansible.builtin.assert:
+    fail_msg: The provided Transparent HugePage shmem_enabled setting is not valid
+    that:
+      - manage_thp_shmem_enabled_setting in ['always', 'within_size', 'advise', 'never', 'deny', 'force']
+  when:
+    - manage_thp_shmem_enabled_setting is defined
+
+- name: Verify the provided Transparent HugePage use_zero_page setting
+  ansible.builtin.assert:
+    fail_msg: The provided Transparent HugePage use_zero_page setting is not valid
+    that:
+      - manage_thp_use_zero_page_setting in ['0', '1']
+  when:
+    - manage_thp_use_zero_page_setting is defined
+
 - name: Create the unit file to configure Transparent HugePage settings
   ansible.builtin.template:
     dest: /etc/systemd/system/{{ manage_thp_service_name }}.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Verify that at least one Transparent HugePage setting is provided
+  ansible.builtin.fail:
+    msg: At least one Transparent HugePage setting must be provided
+  when:
+    - manage_thp_defrag_setting is not defined
+    - manage_thp_enabled_setting is not defined
+    - manage_thp_shmem_enabled_setting is not defined
+    - manage_thp_use_zero_page_setting is not defined
+
 - name: Verify the provided Transparent HugePage "defrag" setting
   ansible.builtin.assert:
     fail_msg: The provided Transparent HugePage "defrag" setting is not valid

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+# Note:
+# The order of any setting's valid values is intentionally _not_ enforced in alphabetical
+# order. They instead match the output of a `cat /path/to/setting` command on a live
+# system so that it is easier to cross-reference the setting values with what one would
+# see when configuring Transparent HugePage settings manually.
+
 - name: Verify that at least one Transparent HugePage setting is provided
   ansible.builtin.fail:
     msg: At least one Transparent HugePage setting must be provided

--- a/templates/configure-thp.service.j2
+++ b/templates/configure-thp.service.j2
@@ -1,0 +1,12 @@
+[Unit]
+After=sysinit.target local-fs.target
+DefaultDependencies=no
+Description=Configure Transparent HugePage (THP) support
+
+[Service]
+ExecStart=/bin/sh -c 'echo {{ manage_thp_defrag_setting }} > {{ manage_thp_defrag_path }}'
+ExecStart=/bin/sh -c 'echo {{ manage_thp_enabled_setting }} > {{ manage_thp_enabled_path }}'
+Type=oneshot
+
+[Install]
+WantedBy=basic.target

--- a/templates/configure-thp.service.j2
+++ b/templates/configure-thp.service.j2
@@ -1,5 +1,8 @@
 [Unit]
 After=sysinit.target local-fs.target
+{% if manage_thp_start_before_service is defined %}
+Before={{ manage_thp_start_before_service }}.service
+{% endif %}
 DefaultDependencies=no
 Description=Configure Transparent HugePage (THP) support
 

--- a/templates/configure-thp.service.j2
+++ b/templates/configure-thp.service.j2
@@ -7,8 +7,12 @@ DefaultDependencies=no
 Description=Configure Transparent HugePage (THP) support
 
 [Service]
+{% if manage_thp_defrag_setting is defined %}
 ExecStart=/bin/sh -c 'echo {{ manage_thp_defrag_setting }} > {{ manage_thp_defrag_path }}'
+{% endif %}
+{% if manage_thp_enabled_setting is defined %}
 ExecStart=/bin/sh -c 'echo {{ manage_thp_enabled_setting }} > {{ manage_thp_enabled_path }}'
+{% endif %}
 Type=oneshot
 
 [Install]

--- a/templates/configure-thp.service.j2
+++ b/templates/configure-thp.service.j2
@@ -13,6 +13,12 @@ ExecStart=/bin/sh -c 'echo {{ manage_thp_defrag_setting }} > {{ manage_thp_defra
 {% if manage_thp_enabled_setting is defined %}
 ExecStart=/bin/sh -c 'echo {{ manage_thp_enabled_setting }} > {{ manage_thp_enabled_path }}'
 {% endif %}
+{% if manage_thp_shmem_enabled_setting is defined %}
+ExecStart=/bin/sh -c 'echo {{ manage_thp_shmem_enabled_setting }} > {{ manage_thp_shmem_enabled_path }}'
+{% endif %}
+{% if manage_thp_use_zero_page_setting is defined %}
+ExecStart=/bin/sh -c 'echo {{ manage_thp_use_zero_page_setting }} > {{ manage_thp_use_zero_page_path }}'
+{% endif %}
 Type=oneshot
 
 [Install]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request implements an Ansible role to configure [Transparent HugePage (THP)](https://www.kernel.org/doc/html/next/admin-guide/mm/transhuge.html) settings.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [GekoCloud/ansible-role-disable-thp](https://github.com/GekoCloud/ansible-role-disable-thp) role is a third-party dependency we use that is not actively maintained. I have had to make a pull request in the past to update that role to align with newer [ansible-lint](https://github.com/ansible/ansible-lint) rules. This has come up again and it made sense at this point to have our own role that implements this functionality to allow straightforward maintenance.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
